### PR TITLE
Enhance Get-AppWorkloadDetails.ps1

### DIFF
--- a/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
+++ b/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
@@ -17,6 +17,12 @@ Switch to retrieve all Win32 App policies from the log file. Use this with the o
 .PARAMETER appNameToSearchFor
 (Optional) The name of the app to filter the Win32 App policies. Used with the `getWin32AppPolicies` parameter.
 
+.PARAMETER DetectionScript
+Switch to include detection script information in the output when retrieving Win32 App policies. Used with the `getWin32AppPolicies` parameter.
+
+.PARAMETER OutGridView
+Switch to display the output in an Out-GridView window when retrieving Win32 App policies. Used with the `getWin32AppPolicies` parameter.
+
 .PARAMETER getWin32AppGRSinfo
 Switch to retrieve GRS (Global Retry Schedule) details for a specific Win32 App ID. Requires the `win32AppID` parameter.
 
@@ -31,6 +37,10 @@ Switch to retrieve ESP (Enrollment Status Page) profile information from the log
 .EXAMPLE
 .\Get-AppWorkloadDetails.ps1 -logFilePath "C:\Logs\AppWorkload.log" -getWin32AppPolicies -appNameToSearchFor "Chrome"
 Retrieves Win32 App policies from the specified log file and filters the results for apps with names containing "Chrome".
+
+.EXAMPLE
+.\Get-AppWorkloadDetails.ps1 -logFilePath "C:\Logs\AppWorkload.log" -getWin32AppPolicies -appNameToSearchFor "Office" -DetectionScript -OutGridView
+Retrieves Win32 App policies for apps with names containing "Office", includes detection script information, and displays the results in an Out-GridView window.
 
 .EXAMPLE
 .\Get-AppWorkloadDetails.ps1 -logFilePath "C:\Logs\AppWorkload-20250314-191451.log" -getWin32AppGRSinfo -win32AppID "09da002a-e50f-459d-8364-b4f8fe012bc3"
@@ -58,6 +68,12 @@ param (
     [Parameter(Mandatory=$false, ParameterSetName="GetWin32AppPolicies")]
     [string]$appNameToSearchFor,
 
+    [Parameter(Mandatory=$false, ParameterSetName="GetWin32AppPolicies")]
+    [switch]$DetectionScript,
+
+    [Parameter(Mandatory=$false, ParameterSetName="GetWin32AppPolicies")]
+    [switch]$OutGridView,
+
     # Params for getting Win32App GRS info
     [Parameter(Mandatory=$true, ParameterSetName="Win32AppGRSinfo")]
     [switch]$getWin32AppGRSinfo,
@@ -80,6 +96,49 @@ function Test-GUID {
     } else {
         return $false
     }
+}
+
+function Get-DetectionScriptInfo {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$ScriptContent
+    )
+    
+    try {
+        # Convert Content from Json
+        $DetectionScriptValue = ($ScriptContent | ConvertFrom-Json -ErrorAction SilentlyContinue)
+        
+        # Check Detection is a Script
+        if ($DetectionScriptValue.DetectionType -eq 3) {
+            # Extract Script Body
+            $DetectionScriptValue = (ConvertFrom-Json ($DetectionScriptValue.DetectionText) | Select-Object -ExpandProperty ScriptBody -ErrorAction SilentlyContinue)
+            # Decode Base64
+            $DetectionScriptValue = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($DetectionScriptValue))
+
+            # Check Script Signature for Signer (CN)
+            if ($DetectionScriptValue -match '# SIG # Begin signature block') {
+                # Convert the detection script string to byte array for Get-AuthenticodeSignature
+                $DetectionScriptSigner = ((Get-AuthenticodeSignature -Content $([System.Text.Encoding]::UTF8.GetBytes($DetectionScriptValue)) -SourcePathOrExtension ".ps1" | Select-Object *).SignerCertificate.Subject -split ',')[0]
+            }
+            else {
+                $DetectionScriptSigner = 'Not Signed'
+            }
+        }
+        else {
+            $DetectionScriptValue = 'Not a Script'
+            $DetectionScriptSigner = 'N/A'
+        }
+    }
+    catch {
+        # Catch any errors during detection script processing
+        $DetectionScriptValue = 'Error'
+        $DetectionScriptSigner = 'Error'
+    }
+
+    return [PSCustomObject]@{
+            DetectionScript = $DetectionScriptValue
+            DetectionSigner = $DetectionScriptSigner
+        }
 }
 
 [string] $ErrorActionPreference = 'Stop'
@@ -122,19 +181,52 @@ try {
         if (-not $filteredApps) {
             throw "No results found for the specified app name: $appNameToSearchFor"
         }
-        
-        # ... show the filtered apps in a table format...
-        $filteredApps | Select-Object `
-            @{Name='Win32 app ID'; Expression={$_.ID}}, `
-            @{Name='Win32 app Name'; Expression={$_.Name}}, `
-            @{Name='Revision'; Expression={$_.Version}}, `
-            @{Name='Intent'; Expression={if ($_.Intent -eq '0') { 'NotTargeted' } elseif ($_.Intent -eq '1') { 'Available' } elseif ($_.Intent -eq '3')  { 'Required' } elseif ($_.Intent -eq '4') { 'Uninstall'} else { 'unknown' }}}, `
-            @{Name='TimeFormat'; Expression={$_.StartDeadlineEx.TimeFormat}}, `
-            @{Name='StartTime'; Expression={if ($_.StartDeadlineEx.StartTime -eq '1/1/0001 12:00:00 AM') { 'ASAP' } else { $_.StartDeadlineEx.StartTime }}}, `
-            @{Name='Deadline'; Expression={if ($_.StartDeadlineEx.Deadline -eq '1/1/0001 12:00:00 AM') { 'ASAP' } else { $_.StartDeadlineEx.Deadline }}}, `
-            @{Name='InstallContext'; Expression={if ($_.InstallContext -eq '0') { 'User' } else { 'System' }}} | 
-            Sort-Object 'Win32 app Name' | 
-            Format-Table -AutoSize
+
+        # Start Building PSCustomObject
+        [Collections.Generic.List[PSCustomObject]]$PolicyApps = @()
+
+        # Loop through the filteredApps
+        foreach ($App in $filteredApps) {
+            $App | ForEach-Object {
+                # Create a PSCustomObject for each App
+                $filteredAppsCustObj = [PSCustomObject]@{
+                    'Win32 app ID'   = $_.ID
+                    'Win32 app Name' = $_.Name
+                    'Revision'       = $_.Version
+                    'Intent'         = switch ($_.Intent) {
+                        0 { 'Not Targeted' }
+                        1 { 'Available' }
+                        3 { 'Required' }
+                        4 { 'Uninstall' }
+                        Default { $_.Intent }
+                    }
+                    'TimeFormat'     = $_.StartDeadlineEx.TimeFormat
+                    StartTime        = if ($_.StartDeadlineEx.StartTime -eq '1/1/0001 12:00:00 AM') { 'ASAP' } else { $_.StartDeadlineEx.StartTime }
+                    Deadline         = if ($_.StartDeadlineEx.Deadline -eq '1/1/0001 12:00:00 AM') { 'ASAP' } else { $_.StartDeadlineEx.Deadline }
+                    InstallContext   = switch ((ConvertFrom-Json $_.InstallEx).RunAs) {
+                        0 { 'USER' }
+                        1 { 'SYSTEM' }
+                        Default { $InstallEx.RunAs }
+                    }
+                }
+
+                # Add Detection Information
+                if ($DetectionScript){
+                    $filteredAppsCustObj | Add-Member -MemberType NoteProperty -Name 'DetectionSigner' -Value $(if ($_.DetectionRule){(Get-DetectionScriptInfo -ScriptContent $_.DetectionRule)}).DetectionSigner
+                    $filteredAppsCustObj | Add-Member -MemberType NoteProperty -Name 'DetectionScript' -Value $(if ($_.DetectionRule){(Get-DetectionScriptInfo -ScriptContent $_.DetectionRule)}).DetectionScript
+                }
+            }
+            
+            # Add PSCustomObject to List
+            $PolicyApps.Add($filteredAppsCustObj)
+        }
+        # Output
+        if ($OutGridView) {
+            $PolicyApps | Sort-Object 'Win32 app Name' | Out-GridView -Title "AppWorkload Policies [Total Records: $($PolicyApps.Count)]" -OutputMode Single
+        }
+        else {
+            $PolicyApps | Sort-Object 'Win32 app Name' | Format-Table -AutoSize
+        }
     }
 
     # If we're looking for GRS info....

--- a/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
+++ b/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
@@ -236,56 +236,55 @@ try {
             throw "The win32AppID is not in the correct format."
         }
 
+        # GRS Line Pattern
         [string]$grsPattern = '<!\[LOG\[\[Win32App\]\[GRSManager\].*'
-        $myGRSMatches = [regex]::Matches($content, $grsPattern)
 
-        $sanitizedEntries = @()
+        # Search for GRS Info
+        $GRSInfoMatches = Select-String -Path "$($logFilePath)" -Pattern $grsPattern
 
-        # ... sanitize the entries to remove the prefix and filter by win32AppID...
-        foreach ($match in $myGRSMatches) {
-            $entry = $match -replace '^\<\!\[LOG\[\[Win32App\]\[GRSManager\] ', ''
-            If ($entry -like "*$win32AppID*") {
-                $sanitizedEntries += $entry
+        # GRS App ID Pattern
+        [string]$grsAppIdPattern = 'Found GRS value: (\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}) at key (.+)'
+
+        # Find all the entries with the AppID and the GRS Pattern
+        $GRSInfoMatches = $GRSInfoMatches | Where-Object { $_ -match "$($win32AppID)" } | Where-Object { $_ -match $grsAppIdPattern }
+
+        # Build a Sortable List to find the latest entry
+        [Collections.Generic.List[PSCustomObject]]$EntryObjects = @()
+        foreach ($Entry in $GRSInfoMatches) {
+            # Build a custom object with the info
+            $GRSInfoObject = [PSCustomObject]@{
+                'DateTime' = [datetime]::ParseExact(([regex]::Matches($Entry, '(\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2})')).Value, "MM/dd/yyyy HH:mm:ss", $null)
+                'LineData' = $Entry
             }
+            # Add to List
+            $EntryObjects.Add($GRSInfoObject)
         }
-        #Write-Host $sanitizedEntries -ForegroundColor Green
 
-        if ($sanitizedEntries.Count -eq 0) {
+        # Get the latest entry by DateTime
+        $LatestEntry = $EntryObjects | Sort-Object DateTime | Select-Object -Last 1
+
+        # Check if we found an entry
+        if ($LatestEntry.Count -ne 0) {
+            # Get RegistryKey and Ensure we are matching on the LatestEntry LineData 
+            $formattedRegistryKey = (($LatestEntry.LineData.ToString() | Select-String -Pattern $grsAppIdPattern).Matches.Groups[2].Value) -replace '=.*', '='
+            $registryKeyToDelete = "HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\Win32Apps\$formattedRegistryKey"
+
+            # Build the Output Objects
+            $GRSInformationTime = $null
+            $GRSInformationTime = [PSCustomObject]@{
+                'Last Install Attempt (UTC)'                = $LatestEntry.DateTime
+                'Retry Window (UTC) - 24 to 30 hours later' = "After $($($LatestEntry.DateTime.AddHours(24)).ToString('MM/dd/yyyy HH:mm:ss')) OR $($($LatestEntry.DateTime.AddHours(30)).ToString('MM/dd/yyyy HH:mm:ss'))"
+            }
+            $GRSInformationKey = [PSCustomObject]@{
+                'Registry Key to delete and restart IME service for fast install retry' = $registryKeyToDelete
+            }
+            
+            # ... show the results in a table format...
+            $GRSInformationTime | Format-Table -AutoSize
+            $GRSInformationKey | Format-Table -AutoSize
+        } else {
             throw "No results found in this log file for the specified win32AppID: $win32AppID"
         }
-        
-        $results = @()
-        $forWin32AppFastRetryDeleteThis = @()
-
-        # ... loop through the sanitized entries and extract the relevant information...
-        # Find the latest entry based on the date and time
-        $latestEntry = $sanitizedEntries |
-        Where-Object { $_ -match "Found GRS value: (\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}) at key (.+)" } |
-        Sort-Object { [datetime]::ParseExact($matches[1], "MM/dd/yyyy HH:mm:ss", $null) } -Descending |
-        Select-Object -First 1
-
-        if ($latestEntry -match "Found GRS value: (\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}) at key (.+)") {
-        $lastInstallAttempt = [datetime]::ParseExact($matches[1], "MM/dd/yyyy HH:mm:ss", $null)
-        $rawRegistryKey = $matches[2]
-        $formattedRegistryKey = $rawRegistryKey -replace "=.*", "="
-        $registryKeyToDelete = "HKLM:\SOFTWARE\Microsoft\IntuneManagementExtension\Win32Apps\$formattedRegistryKey"
-
-        $retryStart = $lastInstallAttempt.AddHours(24)
-        $retryEnd = $lastInstallAttempt.AddHours(30)
-
-        $results += [PSCustomObject]@{
-            'Last Install Attempt (UTC)' = $lastInstallAttempt
-            'Retry Window (UTC) - 24 to 30 hours later' = "After $($retryStart.ToString('MM/dd/yyyy HH:mm:ss')) OR $($retryEnd.ToString('MM/dd/yyyy HH:mm:ss'))"
-        }
-
-        $forWin32AppFastRetryDeleteThis += [PSCustomObject]@{
-            'Registry Key to delete and restart IME service for fast install retry' = $registryKeyToDelete
-        }
-        }
-
-        # ... show the results in a table format...
-        $results | Format-Table -AutoSize
-        $forWin32AppFastRetryDeleteThis | Format-Table -AutoSize
     }
 
     # If we're looking for ESP profile info....

--- a/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
+++ b/PowerShell/IME Logs parsing/Get-AppWorkloadDetails.ps1
@@ -291,56 +291,48 @@ try {
     # If we're looking for ESP profile info....
     # ... check if the log file contains ESP profile information and throw an error if it doesn't...
     if ($getESPprofileInfo) {
-        [string]$espLogPattern = '<!\[LOG\[\[Win32App\]\[EspManager\].*'
-        $espPolicyMatches = [regex]::Matches($content, $espLogPattern)
-    
-        if ($espPolicyMatches.Count -eq 0) {
-            throw "No win32 policy matches found in this log file"
-        }
+        # ESP Pattern
+        [string]$espLogPattern = '^\<\!\[LOG\[\[Win32App\]\[EspManager\] In EspPhase'
 
-    
-        $espSanitizedEntries = @()
-        foreach ($match in $espPolicyMatches) {
-            # If statement is needed, otherwise it will capture other, irellevent entries that are similar in format
-            if ($match.Value -match '^\<\!\[LOG\[\[Win32App\]\[EspManager\] In EspPhase') {
-                # Sanitize the entry and add it to the array
-                $entry = $match.Value -replace '^\<\!\[LOG\[\[Win32App\]\[EspManager\]', ''
-                $espSanitizedEntries += $entry
-            }else{
-                throw "No apps found in the ESP phase in this log file"
-            }
-        }
-    
-        $espResults = @()
-        #Write-Host $espSanitizedEntries -ForegroundColor Green
-    
-        foreach ($entry in $espSanitizedEntries) {
-            # Get the EspPhase
-            if ($entry -match "In EspPhase: ([^\.]+)\.") {
-                $espPhase = $matches[1]
-            }
-    
-            # Get the ID
-            if ($entry -match "\. App ([^ ]+) has been registered for user") {
-                $id = $matches[1]
-            }
-    
-            # Get the app name(s) from the log line matching the regex
-            if ($entry -match "\. App name: (.+?)\]LOG") {
-                $softwareName = $matches[1]
-            }
-    
-            # Add the found details to the results array
-            $espResults += [PSCustomObject]@{
-                'EspPhase'      = $espPhase
-                'ID'            = $id
-                'Software Name' = $softwareName
-            }
-        }
+        # Search Log File(s) for the Pattern
+        $PatternMatches = $null
+        $PatternMatches = Select-String -Path "$($logFilePath)" -Pattern $espLogPattern
 
-        #Write-Host $espResults -ForegroundColor Green
-
-        $espResults | Format-Table -AutoSize
+        # Build a List to find the latest entry
+        [Collections.Generic.List[PSCustomObject]]$espAppEntries = @()
+        foreach ($Entry in $PatternMatches) {
+            # Esp App Info Pattern
+            [string]$espAppInfoPattern = 'In EspPhase: ([^\.]+)\. App ([0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12})([^\.]+)([0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12})?\. App name: (.+?)\]LOG'
+            # Esp App Info Match
+            $espAppInfo = $($Entry.ToString() | Select-String -Pattern $espAppInfoPattern).Matches.Groups
+            # Check for Account Setup
+            if ($espAppInfo[3].Value -match 'user') {
+                # User ID Pattern
+                [string]$UserIDPattern = '[0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12}'
+                # Grab the User ID
+                $UserID = $($espAppInfo[3].Value | Select-String -Pattern $UserIDPattern).Matches.Value
+            }
+            else {
+                $UserID = 'N/A'
+            }
+            # Build a PSCustomObject with the Info
+            $espApp = [PSCustomObject]@{
+                'EspPhase' = $espAppInfo[1].Value
+                'User ID'  = $UserID
+                'App ID'   = $espAppInfo[2].Value
+                'App Name' = $espAppInfo[5].Value
+            }
+            # Add PSCustomObject to List
+            $espAppEntries.Add($espApp)
+        }
+        # Check entries were found
+        if ($espAppEntries.Count -eq 0) {
+            Write-Host -ForegroundColor Yellow "[$(Get-Date -format G)] No ESP App Entries Found"
+        }
+        else {
+            # Display the results
+            $espAppEntries | Format-Table -AutoSize
+        }
     }
 } catch {
     Write-Host $($_.Exception.Message) -ForegroundColor Red


### PR DESCRIPTION
Enhance Get-AppWorkloadDetails.ps1 with new parameters for improved output.

- Added `DetectionScript` parameter to include detection script information when retrieving Win32 App policies.
- Added `OutGridView` parameter to display results in an Out-GridView window. Helps with viewing more columns.
- Updated examples in the documentation to reflect new functionality.
- Changed how the Win32 App policies are built before outputting
- Modified GRS Info Process to ensure proper DataTime Sorting
- Modified ESP Profile Process

These changes aim to provide users with more flexibility and clarity when analyzing Intune AppWorkload log files.

## getWin32AppPolicies
### Detection Info:
See the 'CN=' from the script signature of the detection script. Helpful to determine if the apps are coming from the "Publisher" or from 'Cloud' (Cloud will be signed by 'Patch My PC').
View the Detection Script to see the search terms and versions. This can help for scenarios where the customer deploys 'Adobe Acrobat' and says it's reporting "Not Applicable" because they deployed the x86 version. With the Cloud, the default 'Name' of the app is the same for x64 and x86, so the detection script details help.
<img width="2576" height="653" alt="image" src="https://github.com/user-attachments/assets/acacc69e-714d-473f-a402-d6ee80982646" />

### OutGridView:
Nice to have side scrolling for when you have many columns.
<img width="2573" height="779" alt="image" src="https://github.com/user-attachments/assets/b5d61815-575a-48b3-9b85-d51adc9634bb" />

And you can select 1 record from the OGV and get the output to the console. That way you can copy the ID to use with the GRS parameter
<img width="1746" height="940" alt="image" src="https://github.com/user-attachments/assets/5b86a27f-84a8-4ec9-a86a-41648028ba2c" />

But you can still opt to just output to the console
<img width="1746" height="940" alt="image" src="https://github.com/user-attachments/assets/f2b99053-937a-4c8b-9105-b1580fda0d04" />

## getWin32AppGRSinfo
### Previous Logic
Current Logic is not properly sorting the found matches by the Latest entry.
Example Log:
This example shows 2 GRS DateTimes for the same app id.
<img width="1916" height="734" alt="image" src="https://github.com/user-attachments/assets/f07949fa-93b9-4aa7-9e5c-f4d289a135aa" />
Current Logic find the 'Older' date:
<img width="1746" height="940" alt="image" src="https://github.com/user-attachments/assets/e4bd8593-7898-470e-b96b-c216ed82cb61" />

### New Logic
Updated the logic to build a PSCustomObject to then use for sorting by DateTime resulting in the correct date:
<img width="1730" height="924" alt="image" src="https://github.com/user-attachments/assets/03e07d9e-263b-4fe6-8e43-d521deb29f8b" />

## getESPprofileInfo
Changes the Regex Pattern matching to account for 'DeviceSetup' and 'AccountSetup' phases. Also allows for extracting the user id.

### Previous Logic
Current Logic was returning 0 results with this example log:
[AppWorkload_ESP_Example.log](https://github.com/user-attachments/files/22309203/AppWorkload_ESP_Example.log)
<img width="1746" height="221" alt="image" src="https://github.com/user-attachments/assets/d40f3c8c-2f19-4976-8430-47f171f9ea50" />

### New Logic
New RegEx pattern extracts data for either Setup Type:
<img width="2576" height="491" alt="image" src="https://github.com/user-attachments/assets/f421e178-1068-4e68-9b7f-66abdb222eef" />

Then extracts the User ID if 'AccountSetup':
<img width="1224" height="288" alt="image" src="https://github.com/user-attachments/assets/8f8e1fe6-c23d-4d3b-b493-25c013591383" />

Output using updated logic
<img width="1746" height="435" alt="image" src="https://github.com/user-attachments/assets/2988db87-0086-4343-9633-b56e599e6452" />



