### PR TITLE
Added Test PMPCWebCertificate.ps1

### DIFF
--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -11,11 +11,11 @@ expiration, and subject).
 Absolute HTTP or HTTPS URL to test.
 
 .EXAMPLE
-.\PMPC_Client_WebTest.ps1
+.\Test-PMPCWebCertificate.ps1
 Runs the test against the default URL: https://patchmypc.com
 
 .EXAMPLE
-.\PMPC_Client_WebTest.ps1 -URL "https://example.com"
+.\Test-PMPCWebCertificate.ps1 -URL "https://example.com"
 Runs the same connectivity and certificate checks for a custom URL.
 #>
 

--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -1,0 +1,91 @@
+
+<#
+.SYNOPSIS
+Tests HTTPS connectivity and prints remote certificate details for a URL.
+
+.DESCRIPTION
+Validates the provided URL, performs an HTTP web request, then opens a TCP/TLS
+connection to retrieve and display certificate metadata (thumbprint, issuer,
+expiration, and subject).
+
+.PARAMETER URL
+Absolute HTTP or HTTPS URL to test.
+
+.EXAMPLE
+.\PMPC_Client_WebTest.ps1
+Runs the test against the default URL: https://patchmypc.com
+
+.EXAMPLE
+.\PMPC_Client_WebTest.ps1 -URL "https://example.com"
+Runs the same connectivity and certificate checks for a custom URL.
+#>
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]
+    $URL = "https://patchmypc.com"
+)
+
+# Validate URI
+try {
+    $URI = [System.Uri]::new($URL)
+    $AllowedSchemes = @("http", "https")
+    if (-not ($URI.IsAbsoluteUri -and $AllowedSchemes -contains $URI.Scheme.ToLower())) {
+        return Write-Host "URI must be absolute and use http or https scheme: $URL" -ForegroundColor Red
+    }
+}
+catch {
+    Write-Host "Invalid URI format: $URL" -ForegroundColor Red
+    Write-Host "Example: ""https://example.com""" -ForegroundColor Yellow
+    return    
+}
+
+Write-Host "Running as: [$([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)]" -ForegroundColor DarkGray
+Write-Host "Testing connectivity: [$($URL)]" -ForegroundColor DarkGray
+
+# Test HTTP connectivity
+try {
+    $req = Invoke-WebRequest -Uri $URI -UseBasicParsing -TimeoutSec 10
+    Write-Host "Web Request Status: $($req.StatusCode)" -ForegroundColor Green
+}
+catch {
+    Write-Host $_.Exception.Message -ForegroundColor Red
+}
+
+try {
+    $HostName = $URI.Host
+    $Port = if ($URI.IsDefaultPort) { 443 } else { $URI.Port }
+
+    $tcpClient = [System.Net.Sockets.TcpClient]::new()
+    $tcpClient.Connect($HostName, $Port)
+
+    $sslStream = [System.Net.Security.SslStream]::new(
+        $tcpClient.GetStream(), $false,
+        [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
+    )
+    try {
+        $sslStream.AuthenticateAsClient($HostName)
+        $RemoteCert = $sslStream.RemoteCertificate
+        if ($null -ne $RemoteCert) {
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
+            [PSCustomObject]@{
+                Thumbprint = $cert.Thumbprint
+                Issuer     = $cert.Issuer
+                NotAfter   = $cert.NotAfter
+                Subject    = $cert.Subject
+            } | Format-List
+        }
+        else {
+            Write-Host "No Certificate" -ForegroundColor Red
+        }
+    }
+    finally {
+        $sslStream.Dispose()
+        $tcpClient.Dispose()
+    }
+}
+catch {
+    Write-Host $_.Exception.Message -ForegroundColor Red
+}
+
+Read-Host "Press Enter to exit..."

--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -1,4 +1,3 @@
-
 <#
 .SYNOPSIS
 Tests HTTPS connectivity and prints remote certificate details for a URL.
@@ -88,4 +87,5 @@ catch {
     Write-Host $_.Exception.Message -ForegroundColor Red
 }
 
+# Pause to ensure the user can read the output before the console closes
 Read-Host "Press Enter to exit..."


### PR DESCRIPTION
A script that makes testing if TLS Inspection is occuring by performing a web request and outputing the Certificate Information of the request.

Uses System.Net.Sockets.TcpClient for the certificate check as this works on both Windows PowerShell and PowerShell.

Script Defaults to "https://patchmypc.com" for Client Enrolloment troubeshooting, but can be changed using the 'URL' parameter.

# For Client Enrollment TLS Inspection Troubleshooting
## Success
When the request is successful, the output will show a success 200, and the certificate will be a DigiCert issuer
<img width="1278" height="928" alt="image" src="https://github.com/user-attachments/assets/b249609c-bbd5-4935-b44d-bb17dc2ddeb1" />

## Error: "the underlying connection was closed: Cloud nto establish trust relationship for the SSl/TLs secure channel
<img width="1281" height="928" alt="image" src="https://github.com/user-attachments/assets/4b3ff0c2-a587-48d0-a754-415b2148d277" />
