### PR TITLE
Updated Test PMPCWebCertificate with additional tests

### DIFF
--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -1,16 +1,21 @@
 ﻿<#
 .SYNOPSIS
-Tests HTTPS connectivity and prints remote certificate details for a URL.
+Tests HTTPS connectivity, outputs remote certificate details, and tests revocation for a URL.
 
 .DESCRIPTION
-Validates the provided URL, performs an HTTP web request, then opens a TCP/TLS
-connection to retrieve and display certificate metadata (thumbprint, issuer,
-expiration, and subject). Also performs an online certificate revocation check
-using the OCSP URL embedded in the certificate's AIA extension to verify the
-machine can reach the revocation endpoint (e.g. ocsp.digicert.cn).
+Validates the provided URL, opens a plain TCP connection to verify network
+reachability, then opens a TLS connection to retrieve and display certificate
+metadata (thumbprint, issuer, expiration, and subject). Also verifies the
+certificate chain is trusted by the local Windows certificate store, and
+performs an online revocation check against the OCSP/CRL endpoints for every
+certificate in the chain to verify the machine can reach those endpoints.
 
 .PARAMETER URL
 Absolute HTTP or HTTPS URL to test.
+
+.PARAMETER ShowAllCerts
+When specified, displays all certificates sent by the server (leaf + intermediates).
+By default only the leaf certificate is displayed.
 
 .EXAMPLE
 .\Test-PMPCWebCertificate.ps1
@@ -19,12 +24,20 @@ Runs the test against the default URL: https://patchmypc.com
 .EXAMPLE
 .\Test-PMPCWebCertificate.ps1 -URL "https://example.com"
 Runs the same connectivity and certificate checks for a custom URL.
+
+.EXAMPLE
+.\Test-PMPCWebCertificate.ps1 -URL "https://example.com" -ShowAllCerts
+Runs the checks and displays all certificates in the chain sent by the server.
 #>
 
 param(
     [Parameter(Mandatory = $false)]
     [string]
-    $URL = "https://patchmypc.com"
+    $URL = "https://patchmypc.com",
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $ShowAllCerts
 )
 
 #region Validate URI
@@ -44,141 +57,235 @@ catch {
 
 Write-Host "Running as: [$([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)]" -ForegroundColor DarkGray
 
-#region - Test HTTP connectivity
-# Determines if the endpoint is reachable because Invoke-WebRequest does not validate the certificate
+#region - Test TCP connectivity
+# A plain TCP connect tests network reachability with zero cert/OCSP involvement.
+# Invoke-WebRequest triggers OS-level revocation checks during TLS, which fails when OCSP endpoints are blocked.
 Write-Host "----------------------------------" -ForegroundColor DarkGray
-Write-Host "Testing HTTP Connectivity" -ForegroundColor Cyan
-Write-Host "Verifies the URL is reachable over HTTP, No Cert checks." -ForegroundColor DarkGray
+Write-Host "Testing TCP Connectivity" -ForegroundColor Cyan
+Write-Host "Confirms the host and port are reachable at the network level. No TLS or cert checks." -ForegroundColor DarkGray
 Write-Host "----------------------------------" -ForegroundColor DarkGray
+$Port = if ($URI.IsDefaultPort) { if ($URI.Scheme -eq 'https') { 443 } else { 80 } } else { $URI.Port }
 try {
-    $req = Invoke-WebRequest -Uri $URI -UseBasicParsing -TimeoutSec 10
-    Write-Host "Web Request Status: $($req.StatusCode)" -ForegroundColor Green
+    $tcpTest = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $tcpTest.Connect($URI.Host, $Port)
+        Write-Host "TCP Connect: Succeeded ($($URI.Host):$Port)" -ForegroundColor Green
+    }
+    finally {
+        $tcpTest.Dispose()
+    }
 }
 catch {
-    Write-Host $_.Exception.Message -ForegroundColor Red
+    Write-Host "TCP Connect: Failed ($($URI.Host):$Port) - $($_.Exception.Message)" -ForegroundColor Red
 }
 #endregion
 
-#region - Retrieve and display certificate details
-Write-Host ""
-Write-Host "----------------------------------" -ForegroundColor DarkGray
-Write-Host "Retrieving Certificate Details" -ForegroundColor Cyan
-Write-Host "Connects via TLS and displays the server's certificate metadata, No Cert checks." -ForegroundColor DarkGray
-Write-Host "----------------------------------" -ForegroundColor DarkGray
-try {
-    $HostName = $URI.Host
-    $Port = if ($URI.IsDefaultPort) { 443 } else { $URI.Port }
+if ($URI.Scheme -eq 'https') {
 
-    # Open a TCP connection to the host
-    $tcpClient = [System.Net.Sockets.TcpClient]::new()
-    $tcpClient.Connect($HostName, $Port)
+    # Helper Function: extract URLs from an X509 extension by OID using its formatted ASN.1 text
+    function Get-CertExtensionUrls {
+        param(
+            [System.Security.Cryptography.X509Certificates.X509Certificate2]
+            $Certificate,
+            [string]
+            $Oid
+        )
 
-    # Wrap the TCP connection in an SSL stream; the callback accepts all certificates so we can inspect them manually
-    $sslStream = [System.Net.Security.SslStream]::new(
-        $tcpClient.GetStream(), $false,
-        [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
-    )
+        $extension = $Certificate.Extensions | Where-Object { $_.Oid.Value -eq $Oid } | Select-Object -First 1
+        if (-not $extension) { return $null }
+        $formatted = ([System.Security.Cryptography.AsnEncodedData]::new($extension.Oid, $extension.RawData)).Format($true)
+        return [regex]::Matches($formatted, 'https?://[^\s,;)]+').Value
+    }
+
+    #region - Retrieve and display certificate details
+    Write-Host ""
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "Retrieving Certificate Details" -ForegroundColor Cyan
+    Write-Host "Connects via TLS and displays the server's certificate metadata, No Cert checks." -ForegroundColor DarkGray
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
     try {
-        # Preserve existing protocols and include TLS 1.2
-        $sslProtocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Security.Authentication.SslProtocols]::Tls12
-        # Perform the TLS handshake; revocation check is skipped here and done manually later
-        $sslStream.AuthenticateAsClient($HostName, $null, $sslProtocols, $false)
-        # Get the server's certificate from the SSL stream
-        $RemoteCert = $sslStream.RemoteCertificate
-        if ($null -ne $RemoteCert) {
-            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
+        $HostName = $URI.Host
 
-            $AIAUrls = $null
-            $CRLUrls = $null
-            foreach ($extension in $cert.Extensions) {
-                switch ($extension.Oid.Value) {
-                    '1.3.6.1.5.5.7.1.1' {
-                        # AIA (Authority Information Access)
-                        $formatted = ([System.Security.Cryptography.AsnEncodedData]::new($extension.Oid, $extension.RawData)).Format($true)
-                        $AIAUrls = [regex]::Matches($formatted, 'https?://[^\s,;)]+').Value
-                    }
-                    '2.5.29.31' {
-                        # CRL Distribution Points
-                        $formatted = ([System.Security.Cryptography.AsnEncodedData]::new($extension.Oid, $extension.RawData)).Format($true)
-                        $CRLUrls = [regex]::Matches($formatted, 'https?://[^\s,;)]+').Value
+        # Open a TCP connection to the host
+        $tcpClient = [System.Net.Sockets.TcpClient]::new()
+        $tcpClient.Connect($HostName, $Port)
+
+        # Capture the chain the server actually sent during the TLS handshake.
+        # The callback's X509Chain is built from the certs the server presented (leaf + any intermediates).
+        # Script-scope is used because scriptblock-as-delegate runs in an isolated scope.
+        $Script:ServerSentChain = $null
+        $validationCallback = [System.Net.Security.RemoteCertificateValidationCallback] {
+            param($s, $c, $ch, $e)
+            # ChainElements contains the OS-resolved chain (leaf + intermediates + root).
+            $Script:ServerSentChain = $ch.ChainElements |
+                ForEach-Object { [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($_.Certificate) }
+            $true
+        }
+
+        # Wrap the TCP connection in an SSL stream; the callback accepts all certificates so we can inspect them manually
+        $sslStream = [System.Net.Security.SslStream]::new(
+            $tcpClient.GetStream(), $false, $validationCallback
+        )
+        try {
+            # Preserve existing protocols and include TLS 1.2
+            $sslProtocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Security.Authentication.SslProtocols]::Tls12
+            # Perform the TLS handshake; revocation check is skipped here and done manually later
+            $sslStream.AuthenticateAsClient($HostName, $null, $sslProtocols, $false)
+            # Get the server's certificate from the SSL stream
+            $RemoteCert = $sslStream.RemoteCertificate
+            if ($null -ne $RemoteCert) {
+                $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
+
+                # Capture AIA/CRL URLs from the leaf cert
+                $AIAUrls = Get-CertExtensionUrls -Certificate $Certificate -Oid '1.3.6.1.5.5.7.1.1'
+                $CRLUrls = Get-CertExtensionUrls -Certificate $Certificate -Oid '2.5.29.31'
+
+                # By default show only the leaf cert. -ShowAllCerts shows all certs the server sent.
+                $CertChain = if ($ShowAllCerts -and $Script:ServerSentChain) { $Script:ServerSentChain } else { @($Certificate) }
+                $serverCount = if ($Script:ServerSentChain) { $Script:ServerSentChain.Count } else { 1 }
+                Write-Host "Server sent $($serverCount) cert(s)$(if (-not $ShowAllCerts -and $serverCount -gt 1) { ' (use -ShowAllCerts to see all)' }):" -ForegroundColor DarkGray
+                for ($i = 0; $i -lt $CertChain.Count; $i++) {
+                    $CurrentCert = $CertChain[$i]
+                    $role = if ($i -eq 0) { 'Leaf' } elseif ($i -eq $CertChain.Count - 1 -and $CurrentCert.Subject -eq $CurrentCert.Issuer) { 'Root' } else { 'Intermediate' }
+                    Write-Host "[$i] $role" -ForegroundColor Cyan
+                    [PSCustomObject]@{
+                        Thumbprint = $CurrentCert.Thumbprint
+                        Serial     = $CurrentCert.SerialNumber
+                        Subject    = $CurrentCert.Subject
+                        Issuer     = $CurrentCert.Issuer
+                        NotBefore  = $CurrentCert.NotBefore
+                        NotAfter   = $CurrentCert.NotAfter
+                        AIA        = Get-CertExtensionUrls -Certificate $CurrentCert -Oid '1.3.6.1.5.5.7.1.1'
+                        CRLs       = Get-CertExtensionUrls -Certificate $CurrentCert -Oid '2.5.29.31'
+                    } | Format-List
+                }
+
+            }
+            else {
+                Write-Host "No Certificate" -ForegroundColor Red
+            }
+        }
+        finally {
+            $sslStream.Dispose()
+            $tcpClient.Dispose()
+        }
+    }
+    catch {
+        Write-Host $_.Exception.Message -ForegroundColor Red
+    }
+    #endregion
+
+    #region - Test certificate chain trust
+    Write-Host ""
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "Testing Certificate Chain Trust" -ForegroundColor Cyan
+    Write-Host "Verifies the certificate chain using the Windows trust store without revocation checks." -ForegroundColor DarkGray
+    Write-Host "If this fails, the cert or chain is not trusted by this machine's Windows certificate store." -ForegroundColor DarkGray
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
+
+    if ($null -eq $Certificate) {
+        Write-Host "Skipped - no certificate was retrieved." -ForegroundColor Yellow
+    }
+    else {
+        try {
+            $CertChainTrust = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+            # Skip revocation here so chain trust is evaluated independently of OCSP/CRL reachability
+            $CertChainTrust.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+            # Report every chain problem - don't ignore any validation errors
+            $CertChainTrust.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+            try {
+                $Script:ChainTrustPassed = $CertChainTrust.Build($Certificate)
+                if ($Script:ChainTrustPassed) {
+                    Write-Host "Chain Trust: Passed (signatures, trust, expiration, name)" -ForegroundColor Green
+                }
+                else {
+                    Write-Host "Chain Trust: Failed" -ForegroundColor Red
+                    foreach ($status in $CertChainTrust.ChainStatus) {
+                        Write-Host "  - $($status.Status): $($status.StatusInformation.Trim())" -ForegroundColor Red
                     }
                 }
             }
-            
-            [PSCustomObject]@{
-                Thumbprint = $cert.Thumbprint
-                Issuer     = $cert.Issuer
-                NotAfter   = $cert.NotAfter
-                Subject    = $cert.Subject
-                AIA        = $AIAUrls
-                CRLs       = $CRLUrls
-            } | Format-List
-
+            finally {
+                $CertChainTrust.Dispose()
+            }
         }
-        else {
-            Write-Host "No Certificate" -ForegroundColor Red
+        catch {
+            Write-Host $_.Exception.Message -ForegroundColor Red
         }
     }
-    finally {
-        $sslStream.Dispose()
-        $tcpClient.Dispose()
-    }
-}
-catch {
-    Write-Host $_.Exception.Message -ForegroundColor Red
-}
-#endregion
+    #endregion
 
-#region - Test certificate validity
-# Validates the full trust chain and revocation status using X509Chain.
-try {
+    #region - Test certificate revocation
+    # Contacts live OCSP/CRL endpoints to verify no cert in the chain has been revoked.
+    # Unreachable endpoints are reported separately from actual revocations.
+    Write-Host ""
     Write-Host "----------------------------------" -ForegroundColor DarkGray
-    Write-Host "Testing Certificate Validity" -ForegroundColor Cyan
-    Write-Host "Checks the certificate trust chain and revocation status." -ForegroundColor DarkGray
+    Write-Host "Testing Certificate Revocation" -ForegroundColor Cyan
+    Write-Host "Contacts OCSP/CRL endpoints to check revocation status for each cert in the chain." -ForegroundColor DarkGray
     Write-Host "----------------------------------" -ForegroundColor DarkGray
 
-    # Create a new X509Chain object used to build and validate the certificate chain
-    $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
-    # Contact the OCSP/CRL endpoint to perform a live revocation check (as opposed to Offline or NoCheck)
-    $chain.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::Online
-    # Only check the end-entity (leaf) certificate for revocation, not intermediate or root CAs
-    $chain.ChainPolicy.RevocationFlag = [System.Security.Cryptography.X509Certificates.X509RevocationFlag]::EndCertificateOnly
-    # Do not suppress any validation errors - all chain errors will be surfaced in ChainStatus
-    $chain.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
-    if ($null -eq $cert) {
-        Write-Host "Certificate Check: Skipped - no certificate was retrieved." -ForegroundColor Yellow
-        return
+    if ($null -eq $Certificate) {
+        Write-Host "Skipped - no certificate was retrieved." -ForegroundColor Yellow
     }
-    try {
-        $chainBuilt = $chain.Build($cert)
-        if ($chainBuilt) {
-            Write-Host "Certificate Check: Passed" -ForegroundColor Green
-        }
-        else {
-            foreach ($status in $chain.ChainStatus) {
-                switch ($status.Status) {
-                    'Revoked' {
-                        Write-Host "Certificate Check: Certificate is REVOKED" -ForegroundColor Red
+    elseif (-not $Script:ChainTrustPassed) {
+        Write-Host "Skipped - chain trust failed. Fix the chain before checking revocation." -ForegroundColor Yellow
+    }
+    else {
+        try {
+            # Windows caches OCSP/CRL responses, to manually clear run: certutil -urlcache * delete
+
+            $CertChainRev = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+            # Contact the OCSP/CRL endpoint to perform a live revocation check (as opposed to Offline or NoCheck)
+            $CertChainRev.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::Online
+            # Check every cert in the chain (leaf, intermediates, root) for revocation
+            $CertChainRev.ChainPolicy.RevocationFlag = [System.Security.Cryptography.X509Certificates.X509RevocationFlag]::EntireChain
+            # Suppress RevocationStatusUnknown from the aggregate ChainStatus - we read per-element status directly below
+            $CertChainRev.ChainPolicy.VerificationFlags =
+            [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreCertificateAuthorityRevocationUnknown -bor
+            [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreEndRevocationUnknown
+            try {
+                Write-Host "Performing revocation check..." -ForegroundColor DarkGray
+                [void]$CertChainRev.Build($Certificate)
+                for ($i = 0; $i -lt $CertChainRev.ChainElements.Count; $i++) {
+                    $CurrentCert = $CertChainRev.ChainElements[$i]
+                    # Determine the role of this cert in the chain (same logic as the display section)
+                    $Role = if ($i -eq 0) { 'Leaf' } elseif ($CurrentCert.Certificate.Subject -eq $CurrentCert.Certificate.Issuer) { 'Root' } else { 'Intermediate' }
+                    # Extract CN from the subject for readable output, fall back to thumbprint if no CN
+                    $CommonName = if ($CurrentCert.Certificate.Subject -match 'CN=([^,]+)') { $Matches[1].Trim() } else { $CurrentCert.Certificate.Thumbprint }
+                    # Get the AIA URLs from this cert - these are the OCSP/CRL endpoints that were contacted
+                    $AIAUrls = if ($urls = Get-CertExtensionUrls -Certificate $CurrentCert.Certificate -Oid '1.3.6.1.5.5.7.1.1') { $urls -join ', ' } else { 'none' }
+                    # Look for any revocation-related status on this element specifically
+                    $revStatus = $CurrentCert.ChainElementStatus | Where-Object { $_.Status -in 'Revoked', 'RevocationStatusUnknown', 'OfflineRevocation' } | Select-Object -First 1
+                    if ($null -eq $revStatus) {
+                        Write-Host "  OK         : [$Role] $CommonName [$AIAUrls]" -ForegroundColor Green
                     }
-                    { $_ -in 'RevocationStatusUnknown', 'OfflineRevocation' } {
-                        $ocspUrls = if ($AIAUrls) { $AIAUrls -join ', ' } else { 'unknown' }
-                        Write-Host "Certificate Check: Could not reach OCSP/CRL endpoint - check connectivity to: $ocspUrls" -ForegroundColor Yellow
-                    }
-                    default {
-                        Write-Host "Certificate Check: $($status.Status) - $($status.StatusInformation.Trim())" -ForegroundColor Red
+                    else {
+                        switch ($revStatus.Status) {
+                            'Revoked' {
+                                Write-Host "  REVOKED    : [$Role] $CommonName [$AIAUrls]" -ForegroundColor Red
+                            }
+                            { $_ -in 'RevocationStatusUnknown', 'OfflineRevocation' } {
+                                Write-Host "  UNREACHABLE: [$Role] $CommonName" -ForegroundColor Yellow
+                                Write-Host "               Verify connectivity to: $AIAUrls" -ForegroundColor Yellow
+                            }
+                        }
                     }
                 }
             }
+            finally {
+                $CertChainRev.Dispose()
+            }
+        }
+        catch {
+            Write-Host $_.Exception.Message -ForegroundColor Red
         }
     }
-    finally {
-        $chain.Dispose()
-    }
+    #endregion
 }
-catch {
-    Write-Host $_.Exception.Message -ForegroundColor Red
+else {
+    Write-Host ""
+    Write-Host "Skipping certificate checks: scheme '$($URI.Scheme)' is not https." -ForegroundColor Yellow
 }
-#endregion
 
 # Pause to ensure the user can read the output before the console closes
 Read-Host "Press Enter to exit..."

--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -63,15 +63,37 @@ try {
         [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
     )
     try {
-        $sslStream.AuthenticateAsClient($HostName)
+        # Preserve any pre-configured protocols and ensure TLS 1.2 is always included
+        $sslProtocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Security.Authentication.SslProtocols]::Tls12
+        $sslStream.AuthenticateAsClient($HostName, $null, $sslProtocols, $false)
         $RemoteCert = $sslStream.RemoteCertificate
         if ($null -ne $RemoteCert) {
             $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
+
+            $AIAUrls = $null
+            $CRLUrls = $null
+            foreach ($extension in $cert.Extensions) {
+                switch ($extension.Oid.Value) {
+                    '1.3.6.1.5.5.7.1.1' {
+                        # AIA (Authority Information Access)
+                        $formatted = ([System.Security.Cryptography.AsnEncodedData]::new($extension.Oid, $extension.RawData)).Format($true)
+                        $AIAUrls = [regex]::Matches($formatted, 'https?://[^\s,;)]+').Value
+                    }
+                    '2.5.29.31' {
+                        # CRL Distribution Points
+                        $formatted = ([System.Security.Cryptography.AsnEncodedData]::new($extension.Oid, $extension.RawData)).Format($true)
+                        $CRLUrls = [regex]::Matches($formatted, 'https?://[^\s,;)]+').Value
+                    }
+                }
+            }
+            
             [PSCustomObject]@{
                 Thumbprint = $cert.Thumbprint
                 Issuer     = $cert.Issuer
                 NotAfter   = $cert.NotAfter
                 Subject    = $cert.Subject
+                AIA        = $AIAUrls
+                CRLs       = $CRLUrls
             } | Format-List
         }
         else {

--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Tests HTTPS connectivity, outputs remote certificate details, and tests revocation for a URL.
+Tests HTTPS connectivity, outputs remote leAf certificate details, and tests revocation for a URL.
 
 .DESCRIPTION
 Validates the provided URL, opens a plain TCP connection to verify network
@@ -15,7 +15,7 @@ Absolute HTTP or HTTPS URL to test.
 
 .PARAMETER ShowAllCerts
 When specified, displays all certificates sent by the server (leaf + intermediates).
-By default only the leaf certificate is displayed.
+Shows all certs that were NOT used during revocation
 
 .EXAMPLE
 .\Test-PMPCWebCertificate.ps1
@@ -28,6 +28,11 @@ Runs the same connectivity and certificate checks for a custom URL.
 .EXAMPLE
 .\Test-PMPCWebCertificate.ps1 -URL "https://example.com" -ShowAllCerts
 Runs the checks and displays all certificates in the chain sent by the server.
+
+.NOTES
+    Author:  Michael Escamilla
+    Date:    2026-05-26
+    Version: 2.0
 #>
 
 param(
@@ -98,8 +103,7 @@ if ($URI.Scheme -eq 'https') {
     }
 
     #region - Retrieve and display certificate details
-    Write-Host ""
-    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "`n----------------------------------" -ForegroundColor DarkGray
     Write-Host "Retrieving Certificate Details" -ForegroundColor Cyan
     Write-Host "Connects via TLS and displays the server's certificate metadata, No Cert checks." -ForegroundColor DarkGray
     Write-Host "----------------------------------" -ForegroundColor DarkGray
@@ -118,7 +122,7 @@ if ($URI.Scheme -eq 'https') {
             param($s, $c, $ch, $e)
             # ChainElements contains the OS-resolved chain (leaf + intermediates + root).
             $Script:ServerSentChain = $ch.ChainElements |
-                ForEach-Object { [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($_.Certificate) }
+            ForEach-Object { [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($_.Certificate) }
             $true
         }
 
@@ -135,10 +139,6 @@ if ($URI.Scheme -eq 'https') {
             $RemoteCert = $sslStream.RemoteCertificate
             if ($null -ne $RemoteCert) {
                 $Certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
-
-                # Capture AIA/CRL URLs from the leaf cert
-                $AIAUrls = Get-CertExtensionUrls -Certificate $Certificate -Oid '1.3.6.1.5.5.7.1.1'
-                $CRLUrls = Get-CertExtensionUrls -Certificate $Certificate -Oid '2.5.29.31'
 
                 # By default show only the leaf cert. -ShowAllCerts shows all certs the server sent.
                 $CertChain = if ($ShowAllCerts -and $Script:ServerSentChain) { $Script:ServerSentChain } else { @($Certificate) }
@@ -176,8 +176,7 @@ if ($URI.Scheme -eq 'https') {
     #endregion
 
     #region - Test certificate chain trust
-    Write-Host ""
-    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "`n----------------------------------" -ForegroundColor DarkGray
     Write-Host "Testing Certificate Chain Trust" -ForegroundColor Cyan
     Write-Host "Verifies the certificate chain using the Windows trust store without revocation checks." -ForegroundColor DarkGray
     Write-Host "If this fails, the cert or chain is not trusted by this machine's Windows certificate store." -ForegroundColor DarkGray
@@ -218,10 +217,10 @@ if ($URI.Scheme -eq 'https') {
     #region - Test certificate revocation
     # Contacts live OCSP/CRL endpoints to verify no cert in the chain has been revoked.
     # Unreachable endpoints are reported separately from actual revocations.
-    Write-Host ""
-    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "`n----------------------------------" -ForegroundColor DarkGray
     Write-Host "Testing Certificate Revocation" -ForegroundColor Cyan
     Write-Host "Contacts OCSP/CRL endpoints to check revocation status for each cert in the chain." -ForegroundColor DarkGray
+    Write-Host "The trust path may differ from what the server sent due to AIA fetching or local store resolution." -ForegroundColor DarkGray
     Write-Host "----------------------------------" -ForegroundColor DarkGray
 
     if ($null -eq $Certificate) {
@@ -243,9 +242,16 @@ if ($URI.Scheme -eq 'https') {
             $CertChainRev.ChainPolicy.VerificationFlags =
             [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreCertificateAuthorityRevocationUnknown -bor
             [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::IgnoreEndRevocationUnknown
+            # Seed the intermediate certs so hopefully Windows follows the trust path rather than resolving its own chain via AIA downloads or local store
+            if ($Script:ServerSentChain -and $Script:ServerSentChain.Count -gt 1) {
+                foreach ($serverCert in $Script:ServerSentChain | Select-Object -Skip 1) {
+                    [void]$CertChainRev.ChainPolicy.ExtraStore.Add($serverCert)
+                }
+            }
             try {
                 Write-Host "Performing revocation check..." -ForegroundColor DarkGray
                 [void]$CertChainRev.Build($Certificate)
+
                 for ($i = 0; $i -lt $CertChainRev.ChainElements.Count; $i++) {
                     $CurrentCert = $CertChainRev.ChainElements[$i]
                     # Determine the role of this cert in the chain (same logic as the display section)
@@ -257,17 +263,30 @@ if ($URI.Scheme -eq 'https') {
                     # Look for any revocation-related status on this element specifically
                     $revStatus = $CurrentCert.ChainElementStatus | Where-Object { $_.Status -in 'Revoked', 'RevocationStatusUnknown', 'OfflineRevocation' } | Select-Object -First 1
                     if ($null -eq $revStatus) {
-                        Write-Host "  OK         : [$Role] $CommonName [$AIAUrls]" -ForegroundColor Green
+                        Write-Host "  OK         : [$Role] $($CommonName) - [$($CurrentCert.Certificate.Thumbprint)]" -ForegroundColor Green
                     }
                     else {
                         switch ($revStatus.Status) {
                             'Revoked' {
-                                Write-Host "  REVOKED    : [$Role] $CommonName [$AIAUrls]" -ForegroundColor Red
+                                Write-Host "  REVOKED    : [$Role] $($CommonName) [$($AIAUrls)]" -ForegroundColor Red
                             }
                             { $_ -in 'RevocationStatusUnknown', 'OfflineRevocation' } {
-                                Write-Host "  UNREACHABLE: [$Role] $CommonName" -ForegroundColor Yellow
-                                Write-Host "               Verify connectivity to: $AIAUrls" -ForegroundColor Yellow
+                                Write-Host "  UNREACHABLE: [$Role] $($CommonName)" -ForegroundColor Yellow
+                                Write-Host "               Verify connectivity to: $($AIAUrls)" -ForegroundColor Yellow
                             }
+                        }
+                    }
+                }
+
+                # Notify if Windows resolved a different chain path than the server sent
+                $resolvedThumbs = $CertChainRev.ChainElements | ForEach-Object { $_.Certificate.Thumbprint }
+                $diff = $Script:ServerSentChain | Where-Object { $_.Thumbprint -notin $resolvedThumbs }
+                if ($diff) {
+                    Write-Host "`nWindows resolved a different trust path; $($diff.Count) server-sent cert(s) were not used$(if (-not $ShowAllCerts) { ' (use -ShowAllCerts to see which)' })." -ForegroundColor DarkGray
+                    if ($ShowAllCerts) {
+                        foreach ($excludedCert in $diff) {
+                            $excludedCN = if ($excludedCert.Subject -match 'CN=([^,]+)') { $Matches[1].Trim() } else { $excludedCert.Thumbprint }
+                            Write-Host "  Not used   : $excludedCN [$($excludedCert.Thumbprint)]" -ForegroundColor DarkGray
                         }
                     }
                 }
@@ -283,8 +302,7 @@ if ($URI.Scheme -eq 'https') {
     #endregion
 }
 else {
-    Write-Host ""
-    Write-Host "Skipping certificate checks: scheme '$($URI.Scheme)' is not https." -ForegroundColor Yellow
+    Write-Host "`nSkipping certificate checks: scheme '$($URI.Scheme)' is not https." -ForegroundColor Yellow
 }
 
 # Pause to ensure the user can read the output before the console closes

--- a/PowerShell/Test-PMPCWebCertificate.ps1
+++ b/PowerShell/Test-PMPCWebCertificate.ps1
@@ -1,11 +1,13 @@
-<#
+﻿<#
 .SYNOPSIS
 Tests HTTPS connectivity and prints remote certificate details for a URL.
 
 .DESCRIPTION
 Validates the provided URL, performs an HTTP web request, then opens a TCP/TLS
 connection to retrieve and display certificate metadata (thumbprint, issuer,
-expiration, and subject).
+expiration, and subject). Also performs an online certificate revocation check
+using the OCSP URL embedded in the certificate's AIA extension to verify the
+machine can reach the revocation endpoint (e.g. ocsp.digicert.cn).
 
 .PARAMETER URL
 Absolute HTTP or HTTPS URL to test.
@@ -25,7 +27,7 @@ param(
     $URL = "https://patchmypc.com"
 )
 
-# Validate URI
+#region Validate URI
 try {
     $URI = [System.Uri]::new($URL)
     $AllowedSchemes = @("http", "https")
@@ -38,11 +40,16 @@ catch {
     Write-Host "Example: ""https://example.com""" -ForegroundColor Yellow
     return    
 }
+#endregion
 
 Write-Host "Running as: [$([System.Security.Principal.WindowsIdentity]::GetCurrent().Name)]" -ForegroundColor DarkGray
-Write-Host "Testing connectivity: [$($URL)]" -ForegroundColor DarkGray
 
-# Test HTTP connectivity
+#region - Test HTTP connectivity
+# Determines if the endpoint is reachable because Invoke-WebRequest does not validate the certificate
+Write-Host "----------------------------------" -ForegroundColor DarkGray
+Write-Host "Testing HTTP Connectivity" -ForegroundColor Cyan
+Write-Host "Verifies the URL is reachable over HTTP, No Cert checks." -ForegroundColor DarkGray
+Write-Host "----------------------------------" -ForegroundColor DarkGray
 try {
     $req = Invoke-WebRequest -Uri $URI -UseBasicParsing -TimeoutSec 10
     Write-Host "Web Request Status: $($req.StatusCode)" -ForegroundColor Green
@@ -50,22 +57,33 @@ try {
 catch {
     Write-Host $_.Exception.Message -ForegroundColor Red
 }
+#endregion
 
+#region - Retrieve and display certificate details
+Write-Host ""
+Write-Host "----------------------------------" -ForegroundColor DarkGray
+Write-Host "Retrieving Certificate Details" -ForegroundColor Cyan
+Write-Host "Connects via TLS and displays the server's certificate metadata, No Cert checks." -ForegroundColor DarkGray
+Write-Host "----------------------------------" -ForegroundColor DarkGray
 try {
     $HostName = $URI.Host
     $Port = if ($URI.IsDefaultPort) { 443 } else { $URI.Port }
 
+    # Open a TCP connection to the host
     $tcpClient = [System.Net.Sockets.TcpClient]::new()
     $tcpClient.Connect($HostName, $Port)
 
+    # Wrap the TCP connection in an SSL stream; the callback accepts all certificates so we can inspect them manually
     $sslStream = [System.Net.Security.SslStream]::new(
         $tcpClient.GetStream(), $false,
         [System.Net.Security.RemoteCertificateValidationCallback] { param($s, $c, $ch, $e) $true }
     )
     try {
-        # Preserve any pre-configured protocols and ensure TLS 1.2 is always included
+        # Preserve existing protocols and include TLS 1.2
         $sslProtocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Security.Authentication.SslProtocols]::Tls12
+        # Perform the TLS handshake; revocation check is skipped here and done manually later
         $sslStream.AuthenticateAsClient($HostName, $null, $sslProtocols, $false)
+        # Get the server's certificate from the SSL stream
         $RemoteCert = $sslStream.RemoteCertificate
         if ($null -ne $RemoteCert) {
             $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($RemoteCert)
@@ -95,6 +113,7 @@ try {
                 AIA        = $AIAUrls
                 CRLs       = $CRLUrls
             } | Format-List
+
         }
         else {
             Write-Host "No Certificate" -ForegroundColor Red
@@ -108,6 +127,58 @@ try {
 catch {
     Write-Host $_.Exception.Message -ForegroundColor Red
 }
+#endregion
+
+#region - Test certificate validity
+# Validates the full trust chain and revocation status using X509Chain.
+try {
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
+    Write-Host "Testing Certificate Validity" -ForegroundColor Cyan
+    Write-Host "Checks the certificate trust chain and revocation status." -ForegroundColor DarkGray
+    Write-Host "----------------------------------" -ForegroundColor DarkGray
+
+    # Create a new X509Chain object used to build and validate the certificate chain
+    $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+    # Contact the OCSP/CRL endpoint to perform a live revocation check (as opposed to Offline or NoCheck)
+    $chain.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::Online
+    # Only check the end-entity (leaf) certificate for revocation, not intermediate or root CAs
+    $chain.ChainPolicy.RevocationFlag = [System.Security.Cryptography.X509Certificates.X509RevocationFlag]::EndCertificateOnly
+    # Do not suppress any validation errors - all chain errors will be surfaced in ChainStatus
+    $chain.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+    if ($null -eq $cert) {
+        Write-Host "Certificate Check: Skipped - no certificate was retrieved." -ForegroundColor Yellow
+        return
+    }
+    try {
+        $chainBuilt = $chain.Build($cert)
+        if ($chainBuilt) {
+            Write-Host "Certificate Check: Passed" -ForegroundColor Green
+        }
+        else {
+            foreach ($status in $chain.ChainStatus) {
+                switch ($status.Status) {
+                    'Revoked' {
+                        Write-Host "Certificate Check: Certificate is REVOKED" -ForegroundColor Red
+                    }
+                    { $_ -in 'RevocationStatusUnknown', 'OfflineRevocation' } {
+                        $ocspUrls = if ($AIAUrls) { $AIAUrls -join ', ' } else { 'unknown' }
+                        Write-Host "Certificate Check: Could not reach OCSP/CRL endpoint - check connectivity to: $ocspUrls" -ForegroundColor Yellow
+                    }
+                    default {
+                        Write-Host "Certificate Check: $($status.Status) - $($status.StatusInformation.Trim())" -ForegroundColor Red
+                    }
+                }
+            }
+        }
+    }
+    finally {
+        $chain.Dispose()
+    }
+}
+catch {
+    Write-Host $_.Exception.Message -ForegroundColor Red
+}
+#endregion
 
 # Pause to ensure the user can read the output before the console closes
 Read-Host "Press Enter to exit..."


### PR DESCRIPTION
Script now has 4 tests:
1. A plain TCP connect tests network reachability. Confirms the host and port are reachable at the network level. No TLS or cert checks.

2. Retrieve and display certificate details. Displays leaf cert by default, but can show the entire chain using the '-ShowAllCerts' parameter.

3. Test certificate chain trust. Verifies the certificate chain using the Windows trust store without revocation checks.

4. Test certificate revocation. Contacts OCSP/CRL endpoints to check revocation status for each cert in the chain. Will also show if a different trust path was used than what the Server provides.

## Example:
When Top Level Domain '.cn' is being blocked and the revocation cannot be performed:
<img width="989" height="826" alt="image" src="https://github.com/user-attachments/assets/099cc877-baac-4d34-8fb6-38acfd4200fa" />

## Example:
Using the '-ShowAllCerts' parameter. Revocation test also shows windows used a different Trust Path than the Server provided.
<img width="989" height="1518" alt="image" src="https://github.com/user-attachments/assets/5f054cf6-82d4-4827-88b1-54d8d1231868" />


